### PR TITLE
Proposition de reformulation "X autres produits"

### DIFF
--- a/_includes/phase.html
+++ b/_includes/phase.html
@@ -24,7 +24,7 @@
 		{% if illustrationStartup %}
 			{% include startup-card.html description=illustrationStartup %}
 			<p>
-				<a href="{{ site.baseurl }}startups">{{ startupsCount }} autres produits</a> dans cette phase.
+				<a href="{{ site.baseurl }}startups">{{ startupsCount }} produits au total</a> dans cette phase.
 			</p>
 		{% else %}
 			<em>Revenez bientôt pour voir des produits dans cette phase !</em>


### PR DESCRIPTION
Pour moi "X autres produits" veut dire qu'il y a au total X+1 produits: or le décompte se fait y compris la startup exposée en exemple.

Il me semble que ça serait plus clair comme "X produits au total"

En espérant que je ne reviens pas sur un débat qui aurait déjà eu lieu...