### PR TITLE
Ajout de l'attribut `link`

### DIFF
--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -8,7 +8,7 @@ layout: default
 
 	<h2>{{ page.mission }}</h2>
 
-	{% if page.link %}<a target="_blank" href="{{ page.link }}">{% elseif page.domain %}<a target="_blank" href="https://{{ page.domain }}">{% endif %}
+	{% if page.link %}<a target="_blank" href="{{ page.link }}">{% elsif page.domain %}<a target="_blank" href="https://{{ page.domain }}">{% endif %}
 		{% include screenshot.html startup=page %}
 	{% if page.link or page.domain %}</a>{% endif %}
 
@@ -17,7 +17,7 @@ layout: default
 		<li>Le produit est en <em>{{ page.status}}</em>, il
 			{% if page.link %}
 				est disponible sur <a href="{{ page.link }}" title="{{ page.title }}">{{ page.domain }}</a>.
-			{% elseif page.domain %}
+			{% elsif page.domain %}
 				est disponible sur <a href="https://{{ page.domain }}" title="{{ page.title }}">{{ page.domain }}</a>.
 			{% else %}
 				<em>n'est pas encore accessible au public.</em>

--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -8,14 +8,16 @@ layout: default
 
 	<h2>{{ page.mission }}</h2>
 
-	{%if page.domain %}<a target="_blank" href="https://{{ page.domain }}">{% endif %}
+	{% if page.link %}<a target="_blank" href="{{ page.link }}">{% elseif page.domain %}<a target="_blank" href="https://{{ page.domain }}">{% endif %}
 		{% include screenshot.html startup=page %}
-	{%if page.domain %}</a>{% endif %}
+	{% if page.link or page.domain %}</a>{% endif %}
 
 	<ul>
 		<li>Le porteur administratif est {{ page.owner }}.</li>
 		<li>Le produit est en <em>{{ page.status}}</em>, il
-			{% if page.domain %}
+			{% if page.link %}
+				est disponible sur <a href="{{ page.link }}" title="{{ page.title }}">{{ page.domain }}</a>.
+			{% elseif page.domain %}
 				est disponible sur <a href="https://{{ page.domain }}" title="{{ page.title }}">{{ page.domain }}</a>.
 			{% else %}
 				<em>n'est pas encore accessible au public.</em>

--- a/_startup/chouette.md
+++ b/_startup/chouette.md
@@ -2,6 +2,7 @@
 title: ¡Chouette!
 mission: Recrutez des gens, pas des CV
 domain: chouette.beta.gouv.fr
+link: http://chouette.beta.gouv.fr
 repository: 
 status: construction
 contact: lauren.michel@pole-emploi.fr

--- a/_startup/labonneboite.md
+++ b/_startup/labonneboite.md
@@ -2,6 +2,7 @@
 title: La Bonne Boîte
 mission: Trouvez les entreprises qui vont recruter près de chez vous.
 domain: labonneboite.pole-emploi.fr
+link: http://labonneboite.pole-emploi.fr
 repository:
 status: consolidation
 contact: eric.barthelemy@pole-emploi.fr

--- a/_startup/labonneformation.md
+++ b/_startup/labonneformation.md
@@ -2,6 +2,7 @@
 title: La Bonne Formation
 mission: Recherchez une formation efficace pour votre retour à l'emploi et découvrez les financements possibles.
 domain: labonneformation.pole-emploi.fr
+link: http://labonneformation.pole-emploi.fr
 repository:
 status: consolidation
 contact: christophe.bonraisin@pole-emploi.fr


### PR DESCRIPTION
Certaines startups ne supportent pas encore HTTPS.
Du coup j'ai ajouté un attribut optionnel `link` qui permet de définir exactement l'URL vers la startup.

L'URL par défaut reste `https://{{domain}}`.

Corrections effectuées sur les 3 startups concernées.