### PR TITLE
Ne pas spécifier la hauteur en pixels

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -138,7 +138,7 @@ footer, #masthead {
 }
 
 .ui.card.author>.image>img {
-	max-height: 258px;
+	max-height: 16em;
 	overflow: hidden;
 	object-fit: cover;
 }


### PR DESCRIPTION
Malheureusement ne résoud pas le problème suivant: lorsque je "zoome" trois fois de suite, la photo de Christian se retrouve hors d'alignement vertical (Chrome/Mac)