### PR TITLE
Disable version match check if offline

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,11 @@ rescue Exception => exception
     # Otherwise invite her to report the incident by opening an issue.
     else
       message << "\nSomething went wrong trying to parse production versions."
-      message << "\nPlease report the incident at https://github.com/sgmap/beta.gouv.fr/issues."
+      message << "\nPlease report the incident at https://github.com/sgmap/beta.gouv.fr/issues:"
+      message << "\n"
+      message << "\n\tException name:    #{exception.class.name}"
+      message << "\n\tException message: #{exception.message}"
+      message << "\n"
     end
 
     # In any case, let the user know we're providing a fallback strategy.

--- a/Gemfile
+++ b/Gemfile
@@ -1,16 +1,29 @@
 require 'json'
 require 'open-uri'
 
-versions = JSON.parse(open('https://pages.github.com/versions.json').read)
-
 source 'https://rubygems.org'
 
-# The reason to add a ruby version at .ruby-version and here is to prevent
-# the CI server to push to Github if the versions mismatch.
-# see <https://circleci.com/docs/unrecognized-ruby-version/>
-ruby versions['ruby'] if ENV['CI']
+begin
+  versions = JSON.parse(open('https://pages.github.com/versions.json').read)
 
-# We need to be sure jekyll gets built in CI using the same version
-# than Github does.
-gem 'github-pages', versions['github-pages'], group: :jekyll_plugins
+  # We need to be sure jekyll gets built in CI using the same version
+  # than Github does.
+  gem 'github-pages', versions['github-pages'], group: :jekyll_plugins
+
+  # The reason to add a ruby version at .ruby-version and here is to prevent
+  # the CI server to push to Github if the versions mismatch.
+  # see <https://circleci.com/docs/unrecognized-ruby-version/>
+  ruby versions['ruby'] if ENV['CI']
+
+rescue => unreachable_versions
+  gem 'github-pages'
+
+  if ENV['CI']
+    raise unreachable_versions
+  else
+    puts "\n**Something went wrong trying to parse production versions. Assuming you're offline.**\n\n"
+  end
+end
+
+
 gem 'html-proofer', group: :test


### PR DESCRIPTION
Current behaviour if offline:

```
$ bundle exec jekyll serve
[!] There was an error parsing `Gemfile`: . Bundler cannot continue.
 #  from /Users/sgmap/Dev/beta.gouv.fr/Gemfile:4
 #  -------------------------------------------
 #  
 >  versions = JSON.parse(open('https://pages.github.com/versions.json').read)
 #  
 #  -------------------------------------------
```