### PR TITLE
Add beta banner

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,6 +13,7 @@
 				</div>
 			</nav>
 		</header>
+		<div id="beta">Beta</div>
 
 		{{ content }}
 

--- a/css/main.css
+++ b/css/main.css
@@ -17,6 +17,7 @@ body, .menu {
 
 .menu {
 	text-align: right;
+	padding-right: 2em;
 }
 
 .ui.secondary.menu .item {
@@ -83,6 +84,23 @@ header {
 	background-position: left center;
 	padding-right: 1.5em;
 	margin-right: .8em;
+}
+
+#beta {
+  text-align: center;
+  text-transform: uppercase;
+  position: absolute;
+  top: 21px;
+  right: -40px;
+  -webkit-transform: rotate(45deg);
+  transform: rotate(45deg);
+  width: 150px;
+  background-color: #008cba;
+  color: #fff;
+  padding: 5px;
+  font-size: 15px;
+  font-weight: 700;
+  z-index: 10;
 }
 
 main, section {


### PR DESCRIPTION
Fixes #136 

Avant:

![screen shot 2016-06-19 at 12 42 59](https://cloud.githubusercontent.com/assets/216452/16176875/9702e1dc-361b-11e6-8433-83d57aa98a93.png)

Après:
![screen shot 2016-06-19 at 12 43 11](https://cloud.githubusercontent.com/assets/216452/16176876/9e0e02b8-361b-11e6-9cb6-f95581c0b34b.png)

Je ne suis pas totalement convaincu, c'est un peu redondant avec le logo beta.gouv.fr non? J'ai ramené le logo vers la gauche (2em) pour laisser de la place, mais c'est pas top sur les petits écrans.

Par ailleurs les différents sites des startups n'ont pas systématiquement le bandeau, et l'intérêt du truc serait justement d'avoir une référence visuelle systématique (ça pourrait même être un lien discret vers beta.gouv.fr en mode "que signifie la présence de ce bandeau"). Dans ces conditions je verrais mieux l'intérêt de dire "beta.gouv.fr est en beta comme le sont les autres produits".

Est-ce que l'idée est de supprimer le bandeau "beta" quand on a fait la passation?