### PR TITLE
Utiliser le format png pour gravatar

### DIFF
--- a/_author/florian.md
+++ b/_author/florian.md
@@ -3,7 +3,7 @@ fullname: Florian Delezenne
 role: Développeur
 start: 2014-06-01
 end: 2016-10-21
-avatar: https://www.gravatar.com/userimage/14275002/03a4283cd1632863672a3e249abdb8cb.jpg?size=512
+avatar: https://www.gravatar.com/userimage/14275002/03a4283cd1632863672a3e249abdb8cb.png?size=512
 link: https://github.com/sgmap/beta.gouv.fr/edit/gh-pages/_author/florian.md
 ---
 


### PR DESCRIPTION
Seul mon lien Gravatar ne passe plus en .jpg, plus de problème si je passe en .png mais je n'arrive pas à comprendre la cause.