### PR TITLE
Ajoute les auteurs à un post

### DIFF
--- a/_includes/author.html
+++ b/_includes/author.html
@@ -9,20 +9,23 @@
 	{% endfor %}
 {% endif %}
 
+{% capture avatar %}
+	<img alt="" src="{% if description.avatar %}{{ description.avatar }}{% else %}{{ site.baseurl }}img{{ description.id }}.jpg{% endif %}" />
+{% endcapture %}
+
 
 {% if description.link %}
 <a class="ui card author" {% if description.link %} href="{{ description.link }}" target="_blank" rel="noopener" {% endif %}>
 {% else %}
 <div class="ui card author">
 {% endif %}
-	<div id="{{ description.id | replace:'/author/','' }}" class="image">
-		{% if description.avatar %}
-			<img alt="" src="{{ description.avatar }}" />
-		{% else %}
-			<img alt="" src="{{ site.baseurl }}img{{ description.id }}.jpg" />
-		{% endif %}
-	</div>
+	{% if include.size != 'small' %}
+	<div id="{{ description.id | replace:'/author/','' }}" class="image">{{ avatar }}</div>
+	{% endif %}
 	<div class="content">
+		{% if include.size == 'small' %}
+		<div class="ui mini right floated image">{{ avatar }}</div>
+		{% endif %}
 		<div class="header">{{ description.fullname }}</div>
 		<div class="meta">{{ description.role }}</div>
 		<div class="description">

--- a/_includes/author.html
+++ b/_includes/author.html
@@ -1,23 +1,35 @@
-{% if include.description.link %}
-<a class="ui card author" {% if include.description.link %} href="{{ include.description.link }}" target="_blank" rel="noopener" {% endif %}>
+{% if include.description %}
+	{% assign description = include.description %}
+{% else %}
+	{% capture id %}/author/{{ include.id }}{% endcapture %}
+	{% for author in site.author %}
+		{% if author.id == id %} {% comment %} where query doesn't work on id {% endcomment %}
+			{% assign description = author %}
+		{% endif %}
+	{% endfor %}
+{% endif %}
+
+
+{% if description.link %}
+<a class="ui card author" {% if description.link %} href="{{ description.link }}" target="_blank" rel="noopener" {% endif %}>
 {% else %}
 <div class="ui card author">
 {% endif %}
-	<div id="{{ include.description.id | replace:'/author/','' }}" class="image">
-		{% if include.description.avatar %}
-			<img alt="" src="{{ include.description.avatar }}" />
+	<div id="{{ description.id | replace:'/author/','' }}" class="image">
+		{% if description.avatar %}
+			<img alt="" src="{{ description.avatar }}" />
 		{% else %}
-			<img alt="" src="{{ site.baseurl }}img{{ include.description.id }}.jpg" />
+			<img alt="" src="{{ site.baseurl }}img{{ description.id }}.jpg" />
 		{% endif %}
 	</div>
 	<div class="content">
-		<div class="header">{{ include.description.fullname }}</div>
-		<div class="meta">{{ include.description.role }}</div>
+		<div class="header">{{ description.fullname }}</div>
+		<div class="meta">{{ description.role }}</div>
 		<div class="description">
-			{{ include.description.content }}
+			{{ description.content }}
 		</div>
 	</div>
-{% if include.description.link %}
+{% if description.link %}
 </a>
 {% else %}
 </div>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -14,4 +14,12 @@ layout: default
 			<strong><a class="url" href="{{ page.registration }}">Inscrivez-vous</a> pour participer à l'évènement <span class="summary">{{ page.title }}</span></strong> du <time datetime="{{ page.start }}" class="dtstart"></time> au <time datetime="{{ page.end }}" class="dtend"></time> à <span class="location">{{ page.location }}</span>.
 		</div>
 	{% endif %}
+
+	{% if page.authors %}
+	<div class="cards">
+		{% for author in page.authors %}
+		{% include author.html id=author %}
+		{% endfor %}
+	</div>
+	{% endif %}
 </article>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -16,10 +16,10 @@ layout: default
 	{% endif %}
 
 	{% if page.authors %}
-	<div class="cards">
+	<address class="cards">
 		{% for author in page.authors %}
 		{% include author.html id=author %}
 		{% endfor %}
-	</div>
+	</address>
 	{% endif %}
 </article>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -16,9 +16,9 @@ layout: default
 	{% endif %}
 
 	{% if page.authors %}
-	<address class="cards">
+	<address class="ui stackable cards">
 		{% for author in page.authors %}
-		{% include author.html id=author %}
+		{% include author.html id=author size='small' %}
 		{% endfor %}
 	</address>
 	{% endif %}

--- a/css/post.css
+++ b/css/post.css
@@ -1,3 +1,7 @@
 .vevent .summary {
 	font-weight: bold;
 }
+
+address {
+	font-style: normal;
+}

--- a/css/post.css
+++ b/css/post.css
@@ -4,4 +4,5 @@
 
 address {
 	font-style: normal;
+	font-size: 80%;
 }


### PR DESCRIPTION
Bien évidemment optionnel et rétro compatible.

Dans le front-matter d'un post :

```
authors: florian
```

![capture d ecran 2016-11-03 a 10 37 44](https://cloud.githubusercontent.com/assets/222463/19961293/14cb2654-a1b2-11e6-8df9-938bc373b022.png)

```
authors:
  - mattisg
  - fpagnoux
```

![capture d ecran 2016-11-03 a 10 37 13](https://cloud.githubusercontent.com/assets/222463/19961286/10f3e8ea-a1b2-11e6-8abe-d3a475019c0b.png)