### PR TITLE
Ajout d’un Makefile

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,3 +26,6 @@ insert_final_newline = none
 
 [Gemfile.lock]
 indent_size = none
+
+[Makefile]
+indent_style = tab

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,9 +77,8 @@ Pour l'améliorer, installer [Ruby](https://www.ruby-lang.org/fr/) et [Jekyll](h
 ```sh
 git clone https://github.com/sgmap/beta.gouv.fr.git
 cd beta.gouv.fr
-gem install bundler --no-ri --no-rdoc
-bundle install
-bundle exec jekyll serve
+make install
+make run
 ```
 
 Les fichiers pertinents pour une modification de la présentation sont probablement dans les dossiers `_layouts` et `css`.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+install: ## Installe ou met à jour les dépendances du site
+	command -v bundler >/dev/null 2>&1 || gem install bundler --no-ri --no-rdoc
+	bundle install
+
+run: ## Lance le site avec un serveur local
+	bundle exec jekyll serve
+
+.PHONY: install run


### PR DESCRIPTION
Ce Makefile permet d’avoir une interface standardisée pour :

- installer les dépendances du projet sur sa machine (`make install`)
- lancer le projet en local (`make run`)

Ça rend plus facile les contributions externes. Et aussi ça évite d'écrire le script d'install dans le README :)

Une version longue de l'argument : https://blog.trainline.eu/13439-standardizing-interfaces-across-projects-with-makefiles

Vous en pensez quoi ?