### PR TITLE
Indique que les postes ont été pourvus

### DIFF
--- a/_posts/2016-10-14-Recrutement-gh-apigouv.md
+++ b/_posts/2016-10-14-Recrutement-gh-apigouv.md
@@ -3,6 +3,8 @@ title: api.gouv.fr recrute un ou une growth hacker
 category: recrutement
 ---
 
+**Ce poste a été pourvu.**
+
 Tu veux faire passer <https://api.gouv.fr> à la vitesse supérieure ? On recrute un ou une growth hacker au top !
 
 [Détail de l'annonce](https://gist.github.com/jdesboeufs/01d2a6ecbdfcf3d32708e45603d53e60).

--- a/_posts/2016-12-21-mes-aides-cm.md
+++ b/_posts/2016-12-21-mes-aides-cm.md
@@ -4,6 +4,8 @@ category: recrutement
 startup: mes-aides
 ---
 
+**Ce poste a été pourvu.**
+
 Dans un premier temps, le poste se concentrera sur les besoins de [Mes Aides](https://mes-aides.gouv.fr), un simulateur qui permet à toute personne d’évaluer ses droits à plus d’une vingtaine de prestations sociales. Lancé en 2014, le service est le produit grand public le plus mature de l’Incubateur.
 
 Depuis 2014, l’équipe a mené différentes expériences en termes de communication et d’animation de communautés d’utilisateurs et de partenaires. Ces expériences constituent de premiers apprentissages. Vous venez renforcer l’équipe dans cette mission en consolidant les pratiques actuelles et en proposant des approches nouvelles.

--- a/_posts/2017-01-11-boussole-product-designer.md
+++ b/_posts/2017-01-11-boussole-product-designer.md
@@ -4,6 +4,8 @@ category: recrutement
 startup: boussole
 ---
 
+**Ce poste a été pourvu.**
+
 L'équipe Boussole cherche un·e product designer pour prototyper, tester et implémenter en continu de super améliorations au service !
 
 * Vous voulez faire partie d'une [petite équipe produit autonome](https://beta.gouv.fr/2016/11/28/equipes-autonomes), focalisée autour d'un problème précis ;

--- a/_posts/2017-01-12-mes-aides-dev.md
+++ b/_posts/2017-01-12-mes-aides-dev.md
@@ -4,6 +4,8 @@ category: recrutement
 startup: mes-aides
 ---
 
+**Ce poste a été pourvu.**
+
 Mes Aides cherche un·e dev web full-stack, compétent·e en JS, et intéressé·e par l'ops. Venez aider des dizaines de milliers de personnes à accéder à leurs droits chaque jour !
 
 Vous rejoindrez l'[équipe autonome](https://beta.gouv.fr/2016/11/28/equipes-autonomes) qui développe Mes Aides. Dans un premier temps, votre contribution portera sur des chantiers techniques prioritaires déjà identifiés :


### PR DESCRIPTION
Fixes #506 

Le plus simple à mon avis est d'ouvrir des PR pour rajouter une mention "le poste a été pourvu". De toute façon il faut ouvrir une PR pour modifier le contenu du site...