### PR TITLE
Redirect from old URL of /blog

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,8 +14,6 @@ twitter_id: 715451644683673601  # more stable than the username
 # Plugins
 gems:
   - jekyll-redirect-from
-whitelist:
-  - jekyll-redirect-from
 
 collections:
   startup:

--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,12 @@ description: Nous créons des services publics numériques
 url: https://beta.gouv.fr
 twitter_id: 715451644683673601  # more stable than the username
 
+# Plugins
+gems:
+  - jekyll-redirect-from
+whitelist:
+  - jekyll-redirect-from
+
 collections:
   startup:
     output: true

--- a/blog.html
+++ b/blog.html
@@ -1,6 +1,8 @@
 ---
 title: Blog
 menu_index: 4
+redirect_from:
+-   /annonces
 ---
 
 <section class="ui container">


### PR DESCRIPTION
Fixes #544 