### PR TITLE
Désactive la vérification des espaces à la CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,9 +11,6 @@ insert_final_newline = true
 max_line_length = 9999
 trim_trailing_whitespace = true
 
-[_posts/*]
-trim_trailing_whitespace = false
-
 [{*.yml,Gemfile,Gemfile.lock}]
 indent_size = 2
 indent_style = space

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,6 @@ machine:
 
 dependencies:
   post:
-    - npm install -g eclint@1.1.5
     - pip install --user html5validator
     - bundle exec jekyll --version # print it out
 
@@ -24,5 +23,3 @@ test:
     - ./checks/html5-standard-compliance
     - ./checks/social-network-optimizations
     - ./checks/json-syntax
-  post:
-    - ./checks/whitespace-rules


### PR DESCRIPTION
On va garder ça sous la forme de jardinage occasionnel, c'est trop handicapant pour la contribution dans trop de catégories différentes: _post, _author, _startup...