### PR TITLE
Ajouter un fichier CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+beta.gouv.fr


### PR DESCRIPTION
Fixes #619 

En l'absence d'un fichier CNAME, Github Pages force la valeur de `baseurl` à `/nom_du_depot`, c'est-à-dire en ce qui nous concerne `'/beta.gouv.fr'`. C'est ce qui permet de dispatcher les sites personnels selon des URLs au format `http://username.github.io/nom_du_depot/index.html`.

En présence d'un fichier CNAME `baseurl` est forcé à `""`, du moins c'est ce que je suppose: le seul moyen de tester étant de merger...