### PR TITLE
Reprise de la géo par Etalab

### DIFF
--- a/_startup/ban.md
+++ b/_startup/ban.md
@@ -3,7 +3,7 @@ title: Base adresse nationale
 mission: Référencer l'intégralité des adresses du territoire français
 link: https://adresse.data.gouv.fr
 repository: https://adresse.data.gouv.fr/foss/
-status: construction
+status: success
 contact: adresse@data.gouv.fr
 logo:  https://adresse.data.gouv.fr/static/img/BAN.png
 start: 2014-06-01

--- a/_startup/inspire.md
+++ b/_startup/inspire.md
@@ -3,7 +3,7 @@ title: inspire.data.gouv.fr
 mission: Libérer les données géographiques pour intensifier leurs usages
 link: https://inspire.data.gouv.fr
 repository: https://github.com/sgmap/inspire
-status: consolidation
+status: success
 contact: inspire@data.gouv.fr
 start: 2015-01-01
 owner: Étalab

--- a/_startup/urbaclic.md
+++ b/_startup/urbaclic.md
@@ -1,7 +1,7 @@
 ---
 title: Urbaclic
 mission: Accéder aux règles d'urbanisme en quelques clics
-link: https://urbaclic.beta.gouv.fr
+link: http://www.opendatalab.fr/urbaclic
 repository: https://github.com/sgmap/urbaclic
 status: success
 contact: contact@urbaclic.beta.gouv.fr

--- a/_startup/urbaclic.md
+++ b/_startup/urbaclic.md
@@ -3,7 +3,7 @@ title: Urbaclic
 mission: Accéder aux règles d'urbanisme en quelques clics
 link: https://urbaclic.beta.gouv.fr
 repository: https://github.com/sgmap/urbaclic
-status: construction
+status: success
 contact: contact@urbaclic.beta.gouv.fr
 start: 2016-03-01
 owner: SGAR Occitanie, Étalab


### PR DESCRIPTION
Etalab opère désormais de façon pérenne ces différentes briques qui rejoignent son nouveau "pôle Géo".