### PR TITLE
code libre -> code ouvert

### DIFF
--- a/_layouts/startup.html
+++ b/_layouts/startup.html
@@ -32,7 +32,7 @@ layout: default
 
                 <li>Le code source
                     {% if page.repository %}
-                        <a href="{{ page.repository }}">est libre.</a>
+                        <a href="{{ page.repository }}">est ouvert.</a>
                     {% else %}
                         <em>n'est pas encore ouvert.</em>
                     {% endif %}


### PR DESCRIPTION
- when the code is not published, we write
  “pas encore ouvert”, so the contrary should be
  “ouvert”

- “libre” has some legal implications and
  therefore does not have the same meaning as
  “ouvert”, which is the term we want to use here