### PR TITLE
Corrige l'erreur 404 sur https://beta.gouv.fr/abonnement-confirme

### DIFF
--- a/_pages/fr/abonnement-confirme.html
+++ b/_pages/fr/abonnement-confirme.html
@@ -1,5 +1,6 @@
 ---
 title: Abonnement confirmé
+permalink: /abonnement-confirme
 lang: fr
 ref: subscription
 ---


### PR DESCRIPTION
Fixes #752 