### PR TITLE
Display startups below the section’s description

### DIFF
--- a/_pages/fr/startups.html
+++ b/_pages/fr/startups.html
@@ -21,7 +21,7 @@ ref: portfolio
     {% assign startups = site.startup | where:'status',phase[0] %}
     <section id="{{ phase[0] }}" class="ui three stackable doubling cards container">
         <h2 class="ui divider horizontal">Nos Startups d'État en {{ phase[1].name }}</h2>
-        <div>
+        <div class="ui container">
             {% capture phase_description %}phases/{{phase[0]}}.md{% endcapture %}
             {% capture phase_description %}{% include {{phase_description}} %}{% endcapture %}
             {{ phase_description | markdownify }}
@@ -37,7 +37,7 @@ ref: portfolio
     {% assign startups = site.startup | where:'status',phase[0] %}
     <section id="{{ phase[0] }}" class="ui three stackable doubling cards container">
         <h2 class="ui divider horizontal">Nos Startups d'État {{ phase[1].name }}</h2>
-        <div>
+        <div class="ui container">
             {% capture phase_description %}phases/{{phase[0]}}.md{% endcapture %}
             {% capture phase_description %}{% include {{phase_description}} %}{% endcapture %}
             {{ phase_description | markdownify }}


### PR DESCRIPTION
Avant :

![screen shot 2017-06-29 at 11 47 25](https://user-images.githubusercontent.com/1333173/27681937-1d0c4ea4-5cc1-11e7-83e8-b53729877bad.png)

Après :

![screen shot 2017-06-29 at 11 47 43](https://user-images.githubusercontent.com/1333173/27681941-1e45d646-5cc1-11e7-9a66-9d4af7924475.png)
