### PR TITLE
Séparation des offres disponibles / pourvues

### DIFF
--- a/_includes/job-preview.html
+++ b/_includes/job-preview.html
@@ -1,0 +1,36 @@
+{% if include.job.startup %}
+    {% capture id %}/startup/{{ include.job.startup }}{% endcapture %}
+    {% for currentStartup in site.startup %}
+        {% if currentStartup.id == id %} {% comment %} where query doesn't work on id {% endcomment %}
+            {% assign startup = currentStartup %}
+        {% endif %}
+    {% endfor %}
+{% else %}
+    {% assign startup = false %}
+{% endif %}
+
+<li class="ui segment blog-segment">
+    <a class="blog-segment-link" title="{{ include.job.title }}" href="{{ include.job.url }}"></a>
+
+    <a class="blog-title-link" href="{{ include.job.url }}">{% if startup %}{{ startup.title }}{% else %}beta.gouv.fr{% endif %} recrute {{ include.job.roles | downcase }}</a>
+
+    <div class="excerpt-meta-informations">
+        <div class="excerpt-parution-date">
+            Paru le {{ include.job.date | date: "%d/%m/%Y" }}
+        </div>
+
+        {% if include.job.techno %}
+            <div class="excerpt-job-techno">{{ job.techno }}</div>
+        {% endif %}
+    </div>
+
+    <div>
+        {% if include.job.open %}
+            {{ include.job.excerpt }}
+        {% else %}
+            {{ "**Ce poste a été pourvu.**" | markdownify }}
+        {% endif %}
+    </div>
+
+    <a href="{{ include.job.url }}">Voir l'offre</a>
+</li>

--- a/_pages/fr/recrutement.html
+++ b/_pages/fr/recrutement.html
@@ -1,17 +1,40 @@
 ---
 title: Recrutement
 menu_index: 4
-additional_css: blog
+additional_css:
+- blog
+- recrutement
 permalink: /recrutement/
 lang: fr
 ref: jobs
 ---
 
 <section class="ui container blog-container">
-    <ul>
     {% assign jobs = site.jobs | sort: 'date' | reverse %}
-    {% for job in jobs %}
-        {% include job-preview.html job=job %}
-    {% endfor %}
+    {% assign opened_jobs = jobs | where:'open',true %}
+    {% assign closed_jobs = jobs | where:'open',false %}
+
+    <ul class="job-offers-list">
+        <li>
+            <h2>Offres disponibles</h2>
+        </li>
+
+        {% if opened_jobs[0] %}
+            {% for job in opened_jobs %}
+                {% include job-preview.html job=job %}
+            {% endfor %}
+        {% else %}
+            <li>Nous n'avons aucun poste ouvert pour le moment.</li>
+        {% endif %}
+    </ul>
+
+    <ul class="job-offers-list">
+        <li>
+            <h2>Offres pourvues</h2>
+        </li>
+
+        {% for job in closed_jobs %}
+            {% include job-preview.html job=job %}
+        {% endfor %}
     </ul>
 </section>

--- a/_pages/fr/recrutement.html
+++ b/_pages/fr/recrutement.html
@@ -11,42 +11,7 @@ ref: jobs
     <ul>
     {% assign jobs = site.jobs | sort: 'date' | reverse %}
     {% for job in jobs %}
-        {% if job.startup %}
-            {% capture id %}/startup/{{ job.startup }}{% endcapture %}
-            {% for currentStartup in site.startup %}
-                {% if currentStartup.id == id %} {% comment %} where query doesn't work on id {% endcomment %}
-                    {% assign startup = currentStartup %}
-                {% endif %}
-            {% endfor %}
-        {% else %}
-            {% assign startup = false %}
-        {% endif %}
-
-        <li class="ui segment blog-segment">
-            <a class="blog-segment-link" title="{{ job.title }}" href="{{ job.url }}"></a>
-
-            <a class="blog-title-link" href="{{ job.url }}">{% if startup %}{{ startup.title }}{% else %}beta.gouv.fr{% endif %} recrute {{ job.roles | downcase }}</a>
-
-            <div class="excerpt-meta-informations">
-                <div class="excerpt-parution-date">
-                    Paru le {{ job.date | date: "%d/%m/%Y" }}
-                </div>
-
-                {% if job.techno %}
-                    <div class="excerpt-job-techno">{{ job.techno }}</div>
-                {% endif %}
-            </div>
-
-            <div>
-               {% if job.open %}
-                    {{ job.excerpt }}
-                {% else %}
-                    {{ "**Ce poste a été pourvu.**" | markdownify }}
-                {% endif %}
-            </div>
-
-            <a href="{{ job.url }}">Voir l'offre</a>
-        </li>
+        {% include job-preview.html job=job %}
     {% endfor %}
     </ul>
 </section>

--- a/css/recrutement.css
+++ b/css/recrutement.css
@@ -1,0 +1,8 @@
+.job-offers-list {
+  padding: 0;
+  margin: 0;
+}
+
+.job-offers-list:not(:first-child) {
+  margin-top: 60px;
+}


### PR DESCRIPTION
Séparation de la page recrutement en 2 parties : offres disponibles / offres pourvues. Histoire que les vieilles offres disponibles ne soient pas perdues en milieu de page mais remontent bien en haut de page.