### PR TITLE
Ne pas répéter le titre des articles de blog

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -12,14 +12,14 @@ layout: default
 {% endif %}
 
 <div id="masthead">
-    <h1>{% if startup %}[{{ startup.title }}] {% endif %}{{ page.title}}</h1>
-    <div class="subtitle">Paru le <time datetime="{{ page.date | date:'%Y-%m-%d' }}">{{ page.date | date: "%d/%m/%Y" }}</time></div>
+    <div class="masthead-wrapper">
+        <h1>{{ page.title}}</h1>
+        <p>Paru le <time datetime="{{ page.date | date:'%Y-%m-%d' }}">{{ page.date | date: "%d/%m/%Y" }}</time></p>
+    </div>
 </div>
 
 <div class="post-container">
     <article class="post">
-        <h1>{{ page.title }}</h1>
-
         <div class="excerpt">{{ page.excerpt }}</div>
 
         {% if startup %}

--- a/css/main.css
+++ b/css/main.css
@@ -360,32 +360,31 @@ h1.site-description {
 
 #masthead {
     background-size: cover;
-    background-position: bottom center;
+    background-position: top center;
     background-attachment: fixed;
-    padding: 5em;
+    padding: 5em 0 2.5em;
     color: white;
-    letter-spacing: .05em;
     background-color: #CCC;
     box-shadow: inset 0em 0em 1em #666;
     background-blend-mode: darken;
     position: relative;
+    text-shadow: 7px 3px 16px #000;
 }
 
-#masthead .subtitle {
-    position: absolute;
-    bottom: 1em;
-    left: 5em;
+#masthead .masthead-wrapper {
+    max-width: 740px;
+    width: 100%;
+    padding: 0 20px;
+    margin: 0 auto;
 }
 
 #masthead h1 {
-    text-transform: uppercase;
+    font-size: 300%;
     text-align: left;
     font-weight: bold;
     line-height: 1.25;
-    font-size: 300%;
     max-width: 20em;
-    margin-top: 0;
-    text-shadow: 0 0 .5em #666;
+    margin: 0;
     padding: 0;
 }
 


### PR DESCRIPTION
Fixes #850

 - On ne répète plus le titre
 - Aligne le titre avec le reste du texte
 - Enlève la transformation toUpperCase
 - Ajoute un peu plus d'ombre sur le texte

Avant:
<img width="1440" alt="screen shot 2017-08-31 at 12 35 21" src="https://user-images.githubusercontent.com/1475946/29919268-ee82349a-8e48-11e7-817b-b8218a3a0f8a.png">

Après:
<img width="1440" alt="screen shot 2017-08-31 at 12 35 33" src="https://user-images.githubusercontent.com/1475946/29919269-ee960a56-8e48-11e7-8903-470a78a4430e.png">
