### PR TITLE
Set baseurl to empty string to fix redirections and internal links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,7 @@ email: contact@beta.gouv.fr
 description: Nous créons des services publics numériques
 description_en: We build digital public services
 url: https://beta.gouv.fr
+baseurl: ""
 twitter_id: 715451644683673601  # more stable than the username
 
 # Do not publish future dated blog posts / job offers.


### PR DESCRIPTION
Fixes #851 

Fixes #730 (maybe ? see below)

Related to #730 and should be a "proper" fix, though I'm still not sure how and why #730 was "fixed". I suspect it has to do with the changes introduced by @maukoquiroga to handle French and English versions but I don't have a definite mental model yet of why the new setup works better than the prior one.

See https://github.com/github/pages-gem/issues/350

Proper regression testing is a bit tricky, as behaviour on Heroku is guaranteed to be different from Github Pages. My best idea is to merge and carefully look for any problems in links or redirections.

To reproduce the same conditions locally that obtain in Github Pages I'm using a command line which looks something like

`env JEKYLL_GITHUB_TOKEN=xxx  PAGES_REPO_NWO=sgmap/beta.gouv.fr.git JEKYLL_ENV=production bundle exec jekyll serve --safe --future -H 0.0.0.0 -P 4000`

I've confirmed that the redirection (#851) is fixed locally.