### PR TITLE
Show screenshot instead of logo

### DIFF
--- a/_includes/screenshot.html
+++ b/_includes/screenshot.html
@@ -1,6 +1,7 @@
 {% if include.startup.status != 'investigation' %}
     {% assign startup_id = include.startup.id | remove: '/startup/' %}
-    {% assign screenshot_file = site.static_files | where: 'basename', startup_id | first %}
+    {% assign screenshot_files =  site.static_files | where_exp:"item", "item.path contains '/startup'" %}
+    {% assign screenshot_file = screenshot_files | where: 'basename', startup_id | first %}
 
     {% if screenshot_file %}
         {% assign screenshot_path = screenshot_file.path %}


### PR DESCRIPTION
L'ancienne expression avait pour effet de prendre le premier fichier statique contenant par exemple "la-bonne-boite". On se retrouve donc avec le logo en gros au lieu d'avoir le screenshot.
Avant:
<img width="1161" alt="screen shot 2017-09-18 at 16 17 09" src="https://user-images.githubusercontent.com/1475946/30546412-e0160c90-9c8c-11e7-91ec-5587b5fd13c6.png">

Après:
<img width="1210" alt="screen shot 2017-09-18 at 16 17 20" src="https://user-images.githubusercontent.com/1475946/30546413-e0184078-9c8c-11e7-9cc2-31f3c9403cd7.png">

