### PR TITLE
Switch default lang to FR

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -36,10 +36,10 @@
 
                     {% assign landing_fr = site.pages | where: 'ref', 'landing' | where: 'lang', 'fr' | first %}
                     {% assign landing_en = site.pages | where: 'ref', 'landing' | where: 'lang', 'en' | first %}
-                    {% if page.lang == 'fr' and landing_en %}
-                        <a class="item large screen only" href="{{ landing_en.url }}">English</a>
-                    {% else %}
+                    {% if page.lang == 'en' and landing_fr %}
                         <a class="item large screen only" href="{{ landing_fr.url }}">Français</a>
+                    {% else %}
+                        <a class="item large screen only" href="{{ landing_en.url }}">English</a>
                     {% endif %}
                 </div>
             </nav>


### PR DESCRIPTION
Fixes #880

Another solution would have been to set `lang: fr` on every blog/startup/jobs as such:
<img width="443" alt="screen shot 2017-09-19 at 11 25 09" src="https://user-images.githubusercontent.com/1475946/30585615-b8a38984-9d2d-11e7-9399-beeb57c65cf4.png">
