### PR TITLE
Utiliser les même marges dans la plupart des écrans de beta.gouv.fr

### DIFF
--- a/_includes/job-preview.html
+++ b/_includes/job-preview.html
@@ -9,7 +9,7 @@
     {% assign startup = false %}
 {% endif %}
 
-<li class="ui segment blog-segment">
+<li class="blog-segment">
     <a class="blog-segment-link" title="{{ include.job.title }}" href="{{ include.job.url }}"></a>
 
     <a class="blog-title-link" href="{{ include.job.url }}">{% if startup %}{{ startup.title }}{% else %}beta.gouv.fr{% endif %} recrute {{ include.job.roles | downcase }}</a>

--- a/_layouts/text.html
+++ b/_layouts/text.html
@@ -2,6 +2,6 @@
 layout: default
 ---
 
-<div class="ui text container">
+<section class="ui container blog-container">
     {{ content }}
-</div>
+</section>

--- a/_pages/en/about.md
+++ b/_pages/en/about.md
@@ -2,6 +2,8 @@
 title: About
 layout: text
 permalink: /en/about/
+additional_css:
+- blog
 lang: en
 ref: about
 ---

--- a/_pages/fr/apropos.md
+++ b/_pages/fr/apropos.md
@@ -3,6 +3,8 @@ title: À propos
 menu_index: 3
 layout: text
 permalink: /apropos/
+additional_css:
+- blog
 lang: fr
 ref: about
 ---

--- a/_pages/fr/blog.html
+++ b/_pages/fr/blog.html
@@ -10,9 +10,12 @@ ref: blog
 ---
 
 <section class="ui container blog-container">
+
+    <h2>Notre blog</h2>
+
     <ul>
     {% for post in site.posts %}
-        <li class="ui segment blog-segment">
+        <li class="blog-segment">
             <a class="blog-segment-link" title="{{ post.title }}" href="{{ post.url }}"></a>
 
             {% if post.authors %}

--- a/_pages/fr/contact.md
+++ b/_pages/fr/contact.md
@@ -1,6 +1,8 @@
 ---
 title: Contact
 layout: text
+additional_css:
+- blog
 permalink: /contact/
 lang: fr
 ref: contact

--- a/_pages/fr/ficheproduit.md
+++ b/_pages/fr/ficheproduit.md
@@ -1,6 +1,8 @@
 ---
 title: Rédiger une fiche produit
 layout: text
+additional_css:
+- blog
 permalink: /ficheproduit/
 lang: fr
 ref: product-card

--- a/_pages/fr/suivi.md
+++ b/_pages/fr/suivi.md
@@ -1,6 +1,8 @@
 ---
 title: Suivi d'audience et vie privée
 layout: text
+additional_css:
+- blog
 permalink: /suivi/
 lang: fr
 ref: privacy

--- a/css/blog.css
+++ b/css/blog.css
@@ -14,8 +14,13 @@ p {
 
 .blog-segment {
     position: relative;
-    z-index: 1;
-    background: url('/img/posts/2017-02-16-intrapreneur-startup-d-etat.jpg');
+    background: #fff;
+    box-shadow: 0 1px 2px 0 rgba(34,36,38,.15);
+    margin: 1rem 0;
+    padding: 1em;
+    border-radius: .28571429rem;
+    border: 1px solid rgba(34,36,38,.15);
+    position: relative;
 }
 
 a.blog-segment-link {


### PR DESCRIPTION
Utiliser les même marges dans la plupart des écrans de beta.gouv.fr, sauf recrutement et home qui sont différents.
Avant:
<img width="1440" alt="screen shot 2017-09-20 at 18 01 51" src="https://user-images.githubusercontent.com/1475946/30654325-d1977828-9e2d-11e7-95f3-b1d3541a576c.png">

Après:
<img width="1440" alt="screen shot 2017-09-20 at 18 00 27" src="https://user-images.githubusercontent.com/1475946/30654277-bd1c2eb6-9e2d-11e7-99e7-23527ee6a3d6.png">
