### PR TITLE
Update « fiche produit » Boussole

### DIFF
--- a/_startup/boussole.md
+++ b/_startup/boussole.md
@@ -1,8 +1,8 @@
 ---
 title: Boussole des droits
 mission: Accéder aux conseils d'un·e professionnel·le à proximité pour trouver un logement, une formation ou un emploi
-link: https://boussole.beta.gouv.fr
-repository: https://github.com/sgmap/boussole/
+link:
+repository:
 status: passation
 contact: contact@boussole.beta.gouv.fr
 start: 2015-12-01


### PR DESCRIPTION
This commit solves:

- a broken link (404) to boussole.beta.gouv.fr
- the openness of source code to « pas encore ouvert »