### PR TITLE
Ajoute ancien·ne·s dans le graph communauté

### DIFF
--- a/_pages/fr/communaute.html
+++ b/_pages/fr/communaute.html
@@ -70,7 +70,8 @@ ref: community
         dinsic: [],
         admin: [],
         independent: [],
-        service: []
+        service: [],
+        alumni: []
     };
 
     {% for person in site.authors %}
@@ -86,6 +87,10 @@ ref: community
             window.data[employerType].push({
                 date: '{{ person.end }}',
                 increment: -1
+            });
+            window.data['alumni'].push({
+                date: '{{ person.end }}',
+                increment: 1
             });
         {% endif %}
     {% endfor %}

--- a/js/communaute.js
+++ b/js/communaute.js
@@ -48,6 +48,12 @@ new Chart(document.querySelector('canvas'), {
             backgroundColor: '#EAC8A2',
             steppedLine: true,
             pointRadius: 0
+        }, {
+            data: datasets.alumni.past,
+            label: 'Ancien·ne·s ',  // trailing space to ensure legend complies with French typography rules
+            backgroundColor: '#A2EEAA',
+            steppedLine: true,
+            pointRadius: 0
         }],
     },
     options: {


### PR DESCRIPTION
Réalise #827 "Créer une catégorie "Ancien·ne·s" dans le graphique communauté pour avoir une visibilité sur la communauté active" :
![ancien-ne-s](https://user-images.githubusercontent.com/181349/32419780-0eb058b2-c280-11e7-969d-0ab4a1a5f490.png)
