### PR TITLE
Ré-affiche le contour (outline) sur focus

### DIFF
--- a/_sass/header.scss
+++ b/_sass/header.scss
@@ -53,7 +53,6 @@
 }
 
 .nav a {
-    outline: none;
     cursor: pointer;
     text-decoration: none;
 }

--- a/_sass/subscribe.scss
+++ b/_sass/subscribe.scss
@@ -48,7 +48,6 @@
     transition: all .25s ease-in-out;
     width: 100%;
     border: none;
-    outline: none;
     padding: 16px 64px 16px 20px;
     background-color: #f6f8fe;
     font: inherit;


### PR DESCRIPTION
http://www.outlinenone.com/

> What does the outline property do?
> 
> It provides visual feedback for links that have "focus" when navigating a web document using the TAB key (or equivalent). This is especially useful for folks who can't use a mouse or have a visual impairment. If you remove the outline you are making your site inaccessible for these people.
> 
> Defining focus to navigation elements is an accessibility requirement, it's clearly stated in the Web Content Accessibility Guidelines:
> 
> 2.4.7 Focus Visible: Any keyboard operable user interface has a mode of operation where the keyboard focus indicator is visible. (Level AA)