### PR TITLE
Centre l'image de titre de la page 404

### DIFF
--- a/404.html
+++ b/404.html
@@ -5,7 +5,11 @@ lang: fr
 ref: notfound
 ---
 
-<h1 id="masthead">Vous y êtes presque, continuez à chercher</h1>
+<div id="masthead">
+    <div class="masthead-wrapper">
+        <h1>Vous y êtes presque, continuez à chercher</h1>
+    </div>
+</div>
 
 <section class="ui text container">
     <p>


### PR DESCRIPTION
Avant:
<img width="1440" alt="screen shot 2017-12-14 at 14 52 30" src="https://user-images.githubusercontent.com/1475946/33995703-10486322-e0df-11e7-99bb-3907732596de.png">


Après:
<img width="1440" alt="screen shot 2017-12-14 at 14 52 17" src="https://user-images.githubusercontent.com/1475946/33995707-14dca650-e0df-11e7-87c6-d43d74f9163c.png">

